### PR TITLE
Fix typo: gnis_id

### DIFF
--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -225,7 +225,7 @@ stakeholders.
     - `county_fips` [string]: [FIPS
       code](https://catalog.data.gov/dataset/fips-county-code-look-up-tool)
       of the county
-    - `gnid_id` [long integer]: [GNIS
+    - `gnis_id` [long integer]: [GNIS
       ID](https://geonames.usgs.gov/domestic/index.html) of the
       location
     - `name` [string]: Full name of the location


### PR DESCRIPTION
Correct `gnid_id` to a more respectable `gnis_id` as it is in [the code](https://github.com/jsf9k/cyhy-core/search?q=gnis&unscoped_q=gnis).