### PR TITLE
Add user report to data dictionary

### DIFF
--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -748,7 +748,7 @@ sent to the target
 * `customer` [string]: PCA customer identifier that this user is associated with
 * `customer_defined_labels` [dictionary]: Customer-defined text labels for
 grouping users for statistical purposes
-  
+
 ## scan Database ##
 
 ### certs Collection ###

--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -48,8 +48,8 @@ This information is organized by database and collection (table).
 * [customers Collection](#customers-collection)
 * [emails Collection](#emails-collection)
 * [templates Collection](#templates-collection)
-* [users Collection](#users-collection)
 * [user_reports Collection](#user_reports-collection)
+* [users Collection](#users-collection)
 
 [scan Database:](#scan-database)
 
@@ -735,20 +735,20 @@ sent to the target
   * 0: Does not evoke a sense of greed
   * 1: Email appeals to greed and monetary gain are within the theme of the email
 
+### user_reports Collection ###
+* `assessment` [string]: PCA assessment identifier that this user_report is associated with
+* `campaign` [string]: PCA campaign identifier that this user_report is associated with  
+* `customer` [string]: PCA customer identifier that this user_report is associated with
+* `first_report` [datetime]: Datetime for when the first user click is reported for a campaign
+* `total_num_reports` [integer]: The total number of clicks reported for a campaign
+
 ### users Collection ###
 
 * `_id` [ObjectId]: PCA ID of this user
 * `customer` [string]: PCA customer identifier that this user is associated with
 * `customer_defined_labels` [dictionary]: Customer-defined text labels for
 grouping users for statistical purposes
-
-### user_reports Collection ###
-* `customer` [string]: PCA customer identifier that this user_report is associated with
-* `assessment` [string]: PCA assessment identifier that this user_report is associated with
-* `campaign` [string]: PCA campaign identifier that this user_report is associated with
-* `first_report` [datetime]: Datetime for when the first user click is reported for a campaign
-* `total_num_reports` [integer]: The total number of clicks reported for a campaign
-
+  
 ## scan Database ##
 
 ### certs Collection ###

--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -49,6 +49,7 @@ This information is organized by database and collection (table).
 * [emails Collection](#emails-collection)
 * [templates Collection](#templates-collection)
 * [users Collection](#users-collection)
+* [user_reports Collection](#user_reports-collection)
 
 [scan Database:](#scan-database)
 

--- a/NCATS_Data_Dictionary.md
+++ b/NCATS_Data_Dictionary.md
@@ -742,6 +742,13 @@ sent to the target
 * `customer_defined_labels` [dictionary]: Customer-defined text labels for
 grouping users for statistical purposes
 
+### user_reports Collection ###
+* `customer` [string]: PCA customer identifier that this user_report is associated with
+* `assessment` [string]: PCA assessment identifier that this user_report is associated with
+* `campaign` [string]: PCA campaign identifier that this user_report is associated with
+* `first_report` [datetime]: Datetime for when the first user click is reported for a campaign
+* `total_num_reports` [integer]: The total number of clicks reported for a campaign
+
 ## scan Database ##
 
 ### certs Collection ###


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This pull request is to merge the changes involving adding the user_report document to the NCATs data dictionary. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

With the user_report collection being added to the PCA database, it is necessary to update the data dictionary to describe the new document schema. The changes describe the fields found in the document schema, and their intended purpose. 

This PR should only be merged after https://github.com/cisagov/pca-core/pull/5 is merged 
## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Changes were made to the NCATS_data_dictionary.md file and previewed, and that the link on the table of contents redirects as expected.


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.
